### PR TITLE
[SOLVED] PGR_땅따먹기, 파일명정렬, 오픈채팅방, 방문길이(PGR 12913, 17686, 42888, 49994)

### DIFF
--- a/.idea/algorithm.iml
+++ b/.idea/algorithm.iml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.12 (algorithm)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="17" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/Week08/박건우/[Solved]_PGR_12913_땅따먹기.java
+++ b/Week08/박건우/[Solved]_PGR_12913_땅따먹기.java
@@ -1,0 +1,84 @@
+import java.util.*;
+
+
+class Movement{
+    int row;
+    int column;
+    int score;
+
+    public Movement(int row, int column, int score){
+        this.row = row;
+        this.column = column;
+        this.score = score;
+    }
+
+    @Override
+    public String toString(){
+        return "row : " + row + ", column : " + column + ", score : " + score;
+    }
+}
+
+class Solution {
+    // 같은 열을 연속하여 밟을 수 없음, 열이 4개로 고정됨
+    // 가로 4인 대각 좌우, 가로 3인 대각 좌우, 가로 2인 대각 좌우
+    public static int[] mvC = new int[] {-3, 3, -2, 2, -1, 1};
+
+    static int solution(int[][] land) {
+        int R = land.length;
+        int C = land[0].length;
+        int answer = 0;
+        Movement cur, nCur;
+        int nr, nc, nSc, cntR;
+        cntR = 1;
+        nSc = 0;
+
+        // 점수 저장하는 보드 만듦
+        int[][] scoreBoard = new int[R][C];
+
+        Deque<Movement> dq = new ArrayDeque<>();
+
+        // 0번 행의 4개 열을 모두 덱에 삽입
+        for(int i = 0; i < 4; i++){
+            dq.add(new Movement(0, i, land[0][i]));
+        }
+
+        while(!dq.isEmpty()){
+            while(!dq.isEmpty()) {
+                cur = dq.poll();
+                //System.out.println(cur);
+                // 마지막 라인에 도달하면 현재 점수와 비교하여 큰 값을 취함(최대점수가 목적)
+                if (cur.row == R) {
+                    continue;
+                }
+
+                // 그 외에는 순회하며 벗어나지 않았는지 체크하고 점수 합산하여 덱에 넣음(스코어보드)
+                for (int i = 0; i < 6; i++) {
+                    nr = cur.row + 1;
+                    nc = cur.column + mvC[i];
+                    if (0 <= nr && nr < R && 0 <= nc && nc < C) {
+                        nSc = cur.score + land[nr][nc];
+                        // 스코어보드보다 높은 점수의 탐색만 계속 진행하여 탐색 횟수 줄임
+                        if (nSc > scoreBoard[nr][nc]) {
+                            //dq.add(new Movement(nr, nc, nSc));
+                            scoreBoard[nr][nc] = nSc;
+                        }
+                    }
+                }
+            }
+
+            if(cntR < R-1) {
+                // 0번 행의 4개 열을 모두 덱에 삽입
+                for (int i = 0; i < 4; i++) {
+                    dq.add(new Movement(cntR, i, scoreBoard[cntR][i] ));
+                }
+            }
+            cntR++;
+        }
+
+        for (int i = 0; i < 4; i++) {
+            answer = Math.max(answer, scoreBoard[R-1][i]);
+        }
+
+        return answer;
+    }
+}

--- a/Week08/박건우/[Solved]_PGR_17686_파일명 정렬.java
+++ b/Week08/박건우/[Solved]_PGR_17686_파일명 정렬.java
@@ -1,0 +1,48 @@
+import java.util.*;
+
+class Solution {
+    public String[] seperate(String file){
+        file = file.toLowerCase();
+        String head = file.split("[0-9]")[0];
+        String number = file.substring(head.length());
+        String[] result = {head, number};
+        return result;
+    }
+
+    public String getNumber(String number){
+        StringBuilder sb = new StringBuilder();
+        for(char ch: number.toCharArray()){
+            if(Character.isDigit(ch) && sb.length() <= 5){
+                sb.append(ch);
+            } else{
+                return sb.toString();
+            }
+        }
+        return sb.toString();
+    }
+
+    public String[] solution(String[] files) {
+        Arrays.sort(files, new Comparator<String>() {
+            @Override
+            public int compare(String o1, String o2){
+                // 파일명 분리
+                String[] file1 = seperate(o1);
+                String[] file2 = seperate(o2);
+
+                int headResult = file1[0].compareTo(file2[0]);
+
+                // head 비교가 같으면 숫자로 비교
+                if(headResult == 0){
+                    int num1 = Integer.parseInt(getNumber(file1[1]));
+                    int num2 = Integer.parseInt(getNumber(file2[1]));
+                    return num1 - num2;
+                }
+
+                return headResult;
+            }
+        });
+
+        //String[] answer = {};
+        return files;
+    }
+}

--- a/Week08/박건우/[Solved]_PGR_42888_오픈채팅방.java
+++ b/Week08/박건우/[Solved]_PGR_42888_오픈채팅방.java
@@ -1,0 +1,58 @@
+import java.util.*;
+
+class User{
+    String uid;
+    String nickName;
+
+    public User(String uid, String nickName){
+        this.uid = uid;
+        this.nickName = nickName;
+    }
+}
+
+class Solution {
+    public String[] solution(String[] record) {
+        String[] ipt;
+        String category = "";
+        String uid = "";
+        String nickName = "";
+        Map<String, String> hm = new HashMap<>();
+        List<String[]> messages = new ArrayList<>();
+
+        for(String rec:record){
+            ipt = rec.split(" ");
+            //System.out.println(Arrays.toString(ipt));
+
+            if(!ipt[0].equals("Leave")){
+                category = ipt[0];
+                uid = ipt[1];
+                nickName = ipt[2];
+            } else {
+                category = ipt[0];
+                uid = ipt[1];
+            }
+
+
+            if(category.equals("Enter")){
+                hm.put(uid, nickName);
+                messages.add(new String[] {uid, "님이 들어왔습니다."});
+            } else if(category.equals("Change")){
+                hm.put(uid, nickName);
+            } else if(category.equals("Leave")){
+                messages.add(new String[] {uid, "님이 나갔습니다."});
+            }
+        }
+
+        String[] answer = new String[messages.size()];
+        //System.out.println(hm);
+
+        for(int i = 0; i < messages.size(); i++){
+            //System.out.println(Arrays.toString(messages.get(i)));
+            ipt = messages.get(i);
+            answer[i] = hm.get(ipt[0]) + ipt[1];
+        }
+
+
+        return answer;
+    }
+}

--- a/Week08/박건우/[Solved]_PGR_49994_방문 길이.java
+++ b/Week08/박건우/[Solved]_PGR_49994_방문 길이.java
@@ -1,0 +1,77 @@
+import java.util.*;
+
+
+class Solution {
+    // 위, 아래, 오른쪽, 왼쪽
+    public static int[] mx = {0, 0, 1, -1};
+    public static int[] my = {1, -1, 0, 0};
+
+    public static int move(char order){
+        switch(order){
+            case 'U':
+                return 0;
+            case 'D':
+                return 1;
+            case 'R':
+                return 2;
+            case 'L':
+                return 3;
+        }
+        return -1;
+    }
+
+    public int solution(String dirs) {
+// 초기 시작위치는 좌표평면으로 (0, 0)이고 맨 왼쪽-맨 아래를 (0,0)으로 하면 (5,5)가 됨
+        int cur_x = 5;
+        int cur_y = 5;
+        int nx, ny;
+
+        int answer = 0;
+        StringBuilder sb1 = new StringBuilder();
+        StringBuilder sb2 = new StringBuilder();
+
+        // 방문여부는 "curX-curY-nextX-nextY"와, "nextX-nextY-curX-curY"로 문자열 만들어 집합에 저장
+        Set<String> visited = new HashSet<>();
+
+        for(char ch:dirs.toCharArray()){
+            // 움직임
+            nx = cur_x + mx[move(ch)];
+            ny = cur_y + my[move(ch)];
+
+
+            //System.out.println("nx : "+nx+", ny: "+ny);
+
+            // 범위 체크함
+            if(nx < 0 || 11 <= nx || ny < 0 || 11 <= ny){
+                continue;
+            }
+
+            sb1.append(cur_x);
+            sb1.append(cur_y);
+            sb1.append(nx);
+            sb1.append(ny);
+
+            sb2.append(nx);
+            sb2.append(ny);
+            sb2.append(cur_x);
+            sb2.append(cur_y);
+
+            // 위치 옮김 반영
+            cur_x = nx;
+            cur_y = ny;
+
+            // 방문체크
+            if(!visited.contains(sb1.toString())){
+                //System.out.println("visited check -> cur_x : "+cur_x+", cur_y: "+cur_y);
+                answer += 1;
+                visited.add(sb1.toString());
+                visited.add(sb2.toString());
+            }
+            sb1.setLength(0);
+            sb2.setLength(0);
+        }
+
+
+        return answer;
+    }
+}


### PR DESCRIPTION
<h1>1. 땅따먹기</h1>
- 소요시간 : 45분
- 풀이 :
처음에는 그냥 bfs를 돌렸다
우선 점수를 저장하는 같은 사이즈 배열을 하나 더 만들었고(엄밀히 만들면 맨 윗칸 점수는 반영 안 하므로 열이 한 칸 작아야 함)
덱 자료구조와 탐색을 위한 스태틱 정수 배열, 값 저장을 위한 변수들을 미리 선언한 것 정도였다.

문제에서 바로 밑의 열은 탐색할 수 없다는 제한 조건이 있었기 때문에 바로 밑의 열을 제외하고 바로 아래를 탐색했다.
(가로가) 세 칸인 대각선 좌우, 두 칸인 대각선 좌우, 한 칸인 대각선 좌우를 다음 좌표로 지정했다.
그리고 그 좌표가 선을 벗어나는지 검사했고, 좌표 내의 값이라면 점수 저장용 배열의 같은 위치 점수보다 높은 경우에만 점수 저장하고 덱에 추가하는 식이었다. 점수를 통해 탐색 횟수를 줄이면 통과할 수 있으리라 생각했다.

그러나 채점 중 정확성 테스트에서조차 시간이 생각보다 오래 걸렸고, 효율성 테스트는 역시나 시간 초과였다

시간을 개선할 아이디어는 생각보다 빨리 떠올랐으나, 기존 코드 구조가 있었고 그것을 기반으로 수정해야 했기에 그 부분에서 좀 오래 걸렸던 것 같다..
<h2>그래서 다음과 같이 로직을 변경했다</h2>
1. 0번 열의 4개 행을 덱에 삽입<br>
2. 기존 탐색 조건과 동일한 조건으로 6방향 탐색하고 칸 벗어나지 않으면 도달 시 점수 계산<br>
3. 도달하고 나서 점수가 스코어보드(점수저장배열)의 해당 위치 점수보다 높은 경우 갱신<br>
4. 다시 큐에 다음 행의 스코어보드의 4개 열 삽입<br>
5. 1~4를 반복하여 맨 마지막 행까지 점수 계산하고, 맨 마지막 행의 4개 점수중 최대값 반환<br><br>
개선된 부분
역시 탐색 횟수가 준 것이 큰 것 같다.
처음의 풀이에서는 열은 4개로 고정이지만, 다음 행으로 넘어갈 때에 24번의 탐색이 발생하고, 최대 12개(4개 열에서 3곳씩 탐색)의 원소가 덱에 추가된다. 그러나, 개선된 풀이에서는 다음 행으로 가기 전 행의 스코어보드 4개 원소만 큐에 남아 있으므로 다음 탐색의 횟수가 12 6 = 72번에서 4 6 = 24번이라는 상수로 고정된다.

만약에 12개의 탐색에서 다음 행의 칸을 밟을 때 매번 스코어보드 갱신이 일어난다면, 덱에는 같은 칸을 나타내는 원소가 점수가 낮은 순서에서 높은 순으로 쌓일 것이고, 그것이 반복되면 매 행마다 원소의 개수나 탐색 회수도 배로 늘어날 것이다. 그 점 때문에 행의 크기가 큰 케이스에서 시간 초과가 발생했으리라 생각한다.

또한 매 행마다 배로 시간-공간 복잡도가 커지는 문제를 해결했기 때문에 효율성 테스트도 통과되었을 것이다.

<h1>2. 파일명정렬</h1>
- 소요시간 : 50분<br>
- 풀이 :<br>
초기에는 FileSys 객체를 만들고 객체 내부에 head, number, tail, number(int)를 담아서 해결하려고 했다
그러나, number(int)를 일일히 생성하는 것이 문제였는지, head를 제거하고 남은 문자열을 파싱하는 과정이 문제였는지 2번 테스트 케이스에서 시간 초과가 발생하였다.

그래서 방법을 찾다가 부득이하게 Arrays.sort()에서 Comparator를 구현하고 그 내부에서 파싱도 진행하는 방식으로 선회했다.
이 방법은 head를 먼저 비교한 다음, head가 같은 경우에만 다음 과정을 진행하여 실행 과정을 단축했다. 또한 head와 나머지를 리턴받은 새로운 값으로 비교를 진행하므로, 새 값에서는 대소문자를 통일하고 대소문자가 상이한 원 파일명을 보존할 수 있는 점도 좋았다.

결국 정렬 구현과 파싱 함수 구현이 좀 귀찮았지만, 코드를 함수 단위로 잘 분할하면 원본+@(문자열 파싱과 정수 변형 등의 오버헤드) 정도의 공간 복잡도와 정렬의 시간 복잡도로 문제를 해결할 수 있다(자바도 tim sort를 사용해서 문제에서 요구한 stable을 충족시킨다 생각했는데 카카오 공식 해설은 파이썬, c++만 stable이라고 하더라. 잘못 알았나?)
<h1>3. 오픈채팅방</h1>
- 소요시간 : 40분<br>
- 풀이 :<br>
초기에는 uid, nickname으로 객체를 만들어 저장한 다음 객체의 파라미터 둘을 합쳐서 최종 문장을 구성하려 하였다.
그러나, 겨우 두 문자열을 합치는 것이므로 그냥 String[]을 사용하는 것이 낫다고 생각해서 아이디어를 변경하였다.
크게 설명할 것은 없고 입장, 퇴장, 닉네임변경을 나타내는 record를 순회하며 입장 시에는 uid와 닉네임을 추가(혹은 변경)하였다. 퇴장 시에는 닉네임 변경은 없으므로 uid-퇴장메세지 문장만 추가하였으며, 반대로 닉네임 변경 시에는 문장의 추가는 없고 해시맵에서 uid에 값인 닉네임을 변경하였다.

변경이 이전 메세지에도 영향을 미치지 않았다면 단순히 해시 테이블의 값을 가져와 바로 문장을 생성하면 되었겠지만, 닉네임 변경이 이전 메세지에게도 영향을 미친다. 따라서 uid와 메세지만 저장해 둔 다음에 모든 동작이 끝나고 나서의 uid로 값을 가져오고 이를 메세지와 합치는 식으로 문장을 생성하여 요구 조건을 달성할 수 있었다.

어려운 문제는 아니었으나 내가 주로 하는 실수인 문제 성의없이 읽기와 + 그러고 성급히 코드 작성해서 나중에 헤매기라는 행동을 반복하지 않고 미리 종이를 활용하여 밑그림을 그려서 실수를 줄였고, 그게 성공했다는 점에 의의를 둔다
<h1>4. 방문길이</h1>
- 소요시간 : 40분<br>
- 풀이 :<br>
문제의 요구 사항을 구현하는 데에 특별한 알고리즘이나 자료구조가 필요한 것은 아니었다.
그러나 길을 자료구조로 표현하는 것은 어려웠고, 하나의 좌표나 선으로 방문 과정을 처리할 수는 없었다.
따라서 초기에는 방문 정보를 나타내는 객체를 정의하여 문제를 해결하고자 하였으나, 시간 초과가 발생해서 포기해야 했다.<br>
그래서 (x1, y1) -> (x2, y2) 경로를 이동했다는 것을 처리하기 위해서 문자열을 저장하는 집합을 통해 처리했다.
"x1y1x2y2" 문자열과 "x2y2x1y1" 문자열을 집합에 추가하여 두 좌표 간 경로를 방문했다고 처리했고, 집합에 두 점 사이의 경로를 나타낸 두 문자열이 없으면 추가하고 새로운 길 방문횟수를 추가하였다.(방향 없는 그래프라 양 쪽을 모두 추가)
자바의 문자열 객체 특성상 매번 문자열을 생성하는 것이 부담되어 StringBuilder(그냥 String 객체의 덧셈이나, thread-safe한 stringBuffer대비 코딩 테스크 환경에서 문자열 다루기 제일 좋다!)를 사용하여 문자열을 처리하였는데 생각보다 성능이 잘 나와서 다행이었다.